### PR TITLE
fix adpcm sounding scratchy due to nibbles being swapped (#17)

### DIFF
--- a/rtl/snd/pcm_counter.vhd
+++ b/rtl/snd/pcm_counter.vhd
@@ -113,7 +113,7 @@ begin
 
   -- set the address and nibble
   addr   <= ctr(ADDR_WIDTH downto 1);
-  nibble <= ctr(0);
+  nibble <= not ctr(0);
 
   -- set the done signal
   done <= '1' when ctr_end = ctr(ADDR_WIDTH+1 downto ADDR_WIDTH-6) else '0';


### PR DESCRIPTION
Here is my speculative (I don't have the hardware)  fix for the scratchy ADPCM sound heard in [this video](https://www.youtube.com/watch?v=mi-PZTkBXR4).
Before the fix, odd values of `ctr` were selecting the high nibble, when the opposite should have been true.

This is basically a port of the [openfpga PR](https://github.com/nullobject/openfpga-tecmo/pull/8) 